### PR TITLE
minor fixes / improvements to -c collections

### DIFF
--- a/buzzard.py
+++ b/buzzard.py
@@ -704,8 +704,6 @@ def drawSVG(svg_attributes, attributes, paths):
 
 def generate(labelString):
 
-    print(args)
-
     path_to_script = os.path.dirname(os.path.abspath(__file__))
 
     if args.outMode != 'lib':

--- a/buzzard.py
+++ b/buzzard.py
@@ -853,6 +853,26 @@ def appendLib(scriptStrings, labelStrings, file):
         
         serialNum += 1
 
+    # make sure there are newlines after every element
+    # good solution from SO: https://stackoverflow.com/questions/3095434/inserting-newlines-in-xml-file-generated-via-xml-etree-elementtree-in-python/33956544#33956544
+    def indent(elem, level=0):
+        indent_string="" # you can choose various symbols / strings to indent with... use "" for no indentation
+        i = "\n" + level*indent_string
+        if len(elem):
+            if not elem.text or not elem.text.strip():
+                elem.text = i + indent_string
+            if not elem.tail or not elem.tail.strip():
+                elem.tail = i
+            for elem in elem:
+                indent(elem, level+1)
+            if not elem.tail or not elem.tail.strip():
+                elem.tail = i
+        else:
+            if level and (not elem.tail or not elem.tail.strip()):
+                elem.tail = i
+    
+    indent(root)
+
     return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<!DOCTYPE eagle SYSTEM \"eagle.dtd\">\n" + XMLET.tostring(root, encoding='unicode', method='xml')
 
 def cleanName(name):

--- a/tests/collection.txt
+++ b/tests/collection.txt
@@ -1,2 +1,4 @@
-"tgt swd clk" -s 0.04
-"tgt boot" -s 0.04 -a tl
+"buzzard" -s 0.04
+"is" -s 0.04 -a tl
+"pretty" -s 0.03
+"slick" -s 0.03 -a tl -f Roboto


### PR DESCRIPTION
I got very familiar with using the collection feature today - generating a library of 60+ labels to be used on a dev board. During that process I fixed some problems and cleaned up a little bit.

One difference in functionality to be aware of / discuss (does this break anything for anyone?):
in order to simplify ```-w a``` mode **label serial numbers are now prepended to the name, rather than appended** so that in an Eagle library users will see ```SERIAL#_NAME``` as opposed to the previous method ```NAMESERIAL#```

Changes:
1. serial number prepend
2. handles blank lines in the collection file
3. clean up print statements, program now displays progress in ```-c``` mode