### PR TITLE
Add support for KiCad

### DIFF
--- a/buzzard.py
+++ b/buzzard.py
@@ -729,7 +729,16 @@ def generate(labelString):
 
     path_to_script = os.path.dirname(os.path.abspath(__file__))
 
-    if args.outMode != 'lib':
+    if args.stdout:
+        paths, attributes, svg_attributes = string2paths(renderLabel(labelString).tostring())
+        try:
+            print(drawSVG(svg_attributes, attributes, paths))
+        except:
+            print("Failed to output")
+            sys.exit(0)  # quit Python
+
+
+    elif args.outMode != 'lib':
         paths, attributes, svg_attributes = string2paths(renderLabel(labelString).tostring())
 
         try:
@@ -1101,6 +1110,9 @@ if __name__ == '__main__':
 
     parser.add_argument('-d', dest='destination', default='output',
                     help='Output destination filename (extension depends on -o flag)')
+
+    parser.add_argument('-stdout', dest='stdout', default=False, action='store_true',
+                    help='If Specified output is written to stdout')
 
     parser.add_argument('-c', dest='useCollection', default=False, action='store_true',
                         help='If specified labelText is used as a path to collection script (a text list of labels and options to create)')

--- a/buzzard.py
+++ b/buzzard.py
@@ -443,6 +443,24 @@ def unpackPoly(poly):
                 print('...Polygon #'+str(p)+' was backwards, reversed')
         p += 1
 
+    # check for polys that are within more than 1 other poly,
+    # extract them now, then we append them later
+    # This isn't a perfect solution and only handles a single nesting
+    extraPolys = []
+    polyTmp    = []
+    for j in range(len(poly)):
+        c = 0
+        for k in range(len(poly)):
+            if j == k:
+                continue
+            if isInside(poly[j][0], poly[k]):
+                c += 1
+        if c > 1:
+            extraPolys.append(poly[j])
+        else:
+            polyTmp.append(poly[j])
+
+    poly = polyTmp
     finalPolys = [poly[0]]
 
     p = 1
@@ -505,7 +523,7 @@ def unpackPoly(poly):
         p += 1
 
     #print(finalPolys)
-    return finalPolys
+    return finalPolys + extraPolys
 
 #
 #


### PR DESCRIPTION
This pull request adds support for exporting these beautiful labels into KiCad.

This is designed to work with KiCad Nightly (and v6 when it is released in the coming months)
I've separated the changes out into 3 commits

## Commit 1
KiCad does not support "self-intersecting" polygons, which it appears Eagle does. 
So the first commit addresses this. I have not tested this in Eagle, and currently it only works when 3 polygons are nested, this is the common case seen with a block background. 
Note: this code currently wouldn't handle a case where 4 polygons are nested, but I don't think that occurs with standard letters. Let me know if you know of a counter example.

### Example:
Without any changes, 3 nested contours get combined. You can see that polygon outlines are present but are incorrect.
![Screenshot from 2021-01-14 01-13-52](https://user-images.githubusercontent.com/344310/104467056-cd0df000-5605-11eb-9f9e-2e28130728fa.png)

With this commits changes, note the center polygon is now treated as a separate entity in the footprint.
![Screenshot from 2021-01-14 01-02-34](https://user-images.githubusercontent.com/344310/104465875-7227c900-5604-11eb-9c96-7e91a8b6630f.png)

## Commit 2
Added stdout output mode. The easiest way to drop these labels into KiCad will be through the clipboard.
Enabling output via stdout enables running a script like this:
```
python buzzard.py "<GPIO 10>" -a cc -o ki -stdout | xclip -sel c -noutf8
```
Then simply pasting `Ctrl+V` the generated label onto a board layout.

## Commit 3
Added KiCad output support, KiCad footprints appears to be the best option to create a container around multiple polygons. polygons are defined with a small header/footer and a list of x/y points.

The KiCad output option is enabled with the `-o ki` argument. If writing to a file we use the `.kicad_mod` extension.